### PR TITLE
correct namespace for NotFoundException

### DIFF
--- a/src/Controller/Component/UserToolComponent.php
+++ b/src/Controller/Component/UserToolComponent.php
@@ -15,7 +15,7 @@ use Cake\Utility;
 use Cake\Event\Event;
 use Cake\Controller\ComponentRegistry;
 use Cake\Utility\Hash;
-use Cake\Error\NotFoundException;
+use Cake\Network\Exception\NotFoundException;
 use Cake\Core\Configure;
 use Cake\Network\Response;
 

--- a/src/Model/Behavior/UserBehavior.php
+++ b/src/Model/Behavior/UserBehavior.php
@@ -14,7 +14,7 @@ use Cake\ORM\Table;
 use Cake\ORM\Entity;
 use Cake\Utility\Hash;
 use Cake\Core\Configure;
-use Cake\Error\NotFoundException;
+use Cake\Network\Exception\NotFoundException;
 use Cake\Network\Email\Email;
 use Cake\Event\EventManager;
 use Cake\Auth\PasswordHasherFactory;


### PR DESCRIPTION
Update nameespace `Cake\Error\NotFoundException` to `Cake\Network\Exception\NotFoundException`
